### PR TITLE
PF-71: Add API to get info about a single client

### DIFF
--- a/blueprints/client.py
+++ b/blueprints/client.py
@@ -5,7 +5,7 @@ from flask.views import MethodView
 from containers import Container
 from repositories import ClientRepository
 
-from .util import class_route, json_response
+from .util import class_route, error_response, is_valid_uuid4, json_response
 
 blp = Blueprint('Clients', __name__)
 
@@ -24,3 +24,24 @@ class ListClients(MethodView):
         ]
 
         return json_response(clients, 200)
+
+
+@class_route(blp, '/api/v1/clients/<client_id>')
+class RetrieveClient(MethodView):
+    init_every_request = False
+
+    def get(self, client_id: str, client_repo: ClientRepository = Provide[Container.client_repo]) -> Response:
+        if is_valid_uuid4(client_id) is False:
+            return error_response('Invalid client ID.', 400)
+
+        client = client_repo.get(client_id)
+
+        if client is None:
+            return error_response('Client not found.', 404)
+
+        resp = {
+            'id': client.id,
+            'name': client.name,
+        }
+
+        return json_response(resp, 200)

--- a/blueprints/util.py
+++ b/blueprints/util.py
@@ -1,6 +1,7 @@
 import json
 from collections.abc import Callable
 from typing import Any
+from uuid import UUID
 
 from flask import Blueprint, Response
 from flask.views import MethodView
@@ -13,6 +14,15 @@ def class_route(blueprint: Blueprint, rule: str, **options: Any) -> Callable[[ty
         return cls
 
     return decorator
+
+
+def is_valid_uuid4(uuid: str) -> bool:
+    try:
+        UUID(uuid, version=4)
+    except ValueError:
+        return False
+
+    return True
 
 
 def json_response(data: dict[str, Any] | list[dict[str, Any]], status: int) -> Response:

--- a/repositories/client.py
+++ b/repositories/client.py
@@ -7,6 +7,9 @@ class ClientRepository:
     def create(self, client: Client) -> None:
         raise NotImplementedError  # pragma: no cover
 
+    def get(self, client_id: str) -> Client | None:
+        raise NotImplementedError  # pragma: no cover
+
     def get_all(self) -> Generator[Client, None, None]:
         raise NotImplementedError  # pragma: no cover
 

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -88,7 +88,8 @@ data "google_iam_policy" "default" {
   binding {
     role = "roles/run.invoker"
     members = [
-      data.google_service_account.apigateway.member
+      data.google_service_account.apigateway.member,
+      data.google_service_account.user.member
     ]
   }
 }

--- a/terraform/serviceaccount.tf
+++ b/terraform/serviceaccount.tf
@@ -30,3 +30,12 @@ data "google_service_account" "circleci" {
 
   depends_on = [ google_project_service.iam ]
 }
+
+# Retrieves the service account of the user microservice.
+# This is defined as part of the user microservice
+# This service account is given permissions to access this microservice
+data "google_service_account" "user" {
+  account_id   = "user-svc"
+
+  depends_on = [ google_project_service.iam ]
+}

--- a/tests/blueprints/test_client.py
+++ b/tests/blueprints/test_client.py
@@ -40,3 +40,57 @@ class TestClient(TestCase):
         for i, client in enumerate(clients):
             self.assertEqual(resp_data[i]['id'], client.id)
             self.assertEqual(resp_data[i]['name'], client.name)
+
+    def test_get_client_found(self) -> None:
+        client = Client(
+            id=cast(str, self.faker.uuid4()),
+            name=self.faker.company(),
+            plan=self.faker.random_element(list(Plan)),
+            email_incidents=self.faker.unique.email(),
+        )
+
+        client_repo_mock = Mock(ClientRepository)
+        cast(Mock, client_repo_mock.get).return_value = client
+
+        with self.app.container.client_repo.override(client_repo_mock):
+            resp = self.client.get(f'/api/v1/clients/{client.id}')
+
+        cast(Mock, client_repo_mock.get).assert_called_once_with(client.id)
+
+        self.assertEqual(resp.status_code, 200)
+        resp_data = json.loads(resp.get_data())
+
+        self.assertEqual(resp_data['id'], client.id)
+        self.assertEqual(resp_data['name'], client.name)
+
+    def test_get_client_missing(self) -> None:
+        client_id = cast(str, self.faker.uuid4())
+        client_repo_mock = Mock(ClientRepository)
+        cast(Mock, client_repo_mock.get).return_value = None
+
+        with self.app.container.client_repo.override(client_repo_mock):
+            resp = self.client.get(f'/api/v1/clients/{client_id}')
+
+        cast(Mock, client_repo_mock.get).assert_called_once_with(client_id)
+
+        self.assertEqual(resp.status_code, 404)
+        resp_data = json.loads(resp.get_data())
+
+        self.assertEqual(resp_data['code'], 404)
+        self.assertEqual(resp_data['message'], 'Client not found.')
+
+    def test_get_client_invalid(self) -> None:
+        client_id = self.faker.word()
+        client_repo_mock = Mock(ClientRepository)
+        cast(Mock, client_repo_mock.get).return_value = None
+
+        with self.app.container.client_repo.override(client_repo_mock):
+            resp = self.client.get(f'/api/v1/clients/{client_id}')
+
+        cast(Mock, client_repo_mock.get).assert_not_called()
+
+        self.assertEqual(resp.status_code, 400)
+        resp_data = json.loads(resp.get_data())
+
+        self.assertEqual(resp_data['code'], 400)
+        self.assertEqual(resp_data['message'], 'Invalid client ID.')

--- a/tests/repositories/firestore/test_client.py
+++ b/tests/repositories/firestore/test_client.py
@@ -62,6 +62,18 @@ class TestClient(TestCase):
         del client_dict['id']
         self.assertEqual(doc.to_dict(), client_dict)
 
+    def test_get_existing(self) -> None:
+        client = self.add_random_clients(1)[0]
+
+        client_repo = self.repo.get(client.id)
+
+        self.assertEqual(client_repo, client)
+
+    def test_get_missing(self) -> None:
+        client_repo = self.repo.get(cast(str, self.faker.uuid4()))
+
+        self.assertIsNone(client_repo)
+
     def test_get_all(self) -> None:
         clients = self.add_random_clients(5)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new API endpoint to retrieve client details by ID.
	- Added validation for client ID format to ensure it is a valid UUID.
	- Enhanced Firestore repository methods for better client data retrieval.
	- Expanded IAM policy for Cloud Run service to include additional service account access.
	- Introduced a new service account for user microservice access.

- **Bug Fixes**
	- Improved error handling for missing or invalid client IDs in API responses.

- **Tests**
	- Expanded test coverage for client retrieval scenarios, including successful, missing, and invalid client IDs.
	- Added tests for Firestore client retrieval, covering existing and non-existing clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->