### PR TITLE
PF-48: Add internal api to get info about a employee

### DIFF
--- a/blueprints/employee.py
+++ b/blueprints/employee.py
@@ -16,11 +16,12 @@ from models import Employee, InvitationResponse, InvitationStatus, Role
 from repositories import EmployeeRepository
 from repositories.errors import DuplicateEmailError
 
-from .util import class_route, error_response, json_response, requires_token, validation_error_response
+from .util import class_route, error_response, is_valid_uuid4, json_response, requires_token, validation_error_response
 
 blp = Blueprint('Employees', __name__)
 
 JSON_VALIDATION_ERROR = 'Request body must be a JSON object.'
+EMPLOYEE_NOT_FOUND_ERROR = 'Employee not found.'
 
 
 def employee_to_dict(employee: Employee) -> dict[str, Any]:
@@ -70,7 +71,30 @@ class EmployeeInfo(MethodView):
         employee = employee_repo.get(employee_id=token['sub'], client_id=token['cid'])
 
         if employee is None:
-            return error_response('Employee not found', 404)
+            return error_response(EMPLOYEE_NOT_FOUND_ERROR, 404)
+
+        return json_response(employee_to_dict(employee), 200)
+
+
+# Internal only
+@class_route(blp, '/api/v1/employees/<client_id>/<employee_id>')
+class RetrieveEmployee(MethodView):
+    init_every_request = False
+
+    def get(
+        self, client_id: str, employee_id: str, employee_repo: EmployeeRepository = Provide[Container.employee_repo]
+    ) -> Response:
+        if not is_valid_uuid4(client_id):
+            return error_response('Invalid client ID.', 400)
+
+        if not is_valid_uuid4(employee_id):
+            return error_response('Invalid employee ID.', 400)
+
+        cid = None if client_id == '00000000-0000-0000-0000-000000000000' else client_id
+        employee = employee_repo.get(employee_id=employee_id, client_id=cid)
+
+        if employee is None:
+            return error_response(EMPLOYEE_NOT_FOUND_ERROR, 404)
 
         return json_response(employee_to_dict(employee), 200)
 
@@ -190,7 +214,7 @@ class EmployeeInvite(MethodView):
         employee = employee_repo.find_by_email(data.email)
 
         if employee is None:
-            return error_response('Employee not found.', 404)
+            return error_response(EMPLOYEE_NOT_FOUND_ERROR, 404)
 
         # Validate employee state
         error_message = None
@@ -249,7 +273,7 @@ class EmployeeInvitationResponse(MethodView):
         error_code = None
 
         if employee is None:
-            return error_response('Employee not found', 404)
+            return error_response(EMPLOYEE_NOT_FOUND_ERROR, 404)
 
         if employee.client_id is None:
             error_message = 'No invitation to respond to'
@@ -315,6 +339,6 @@ class EmployeeDetail(MethodView):
         employee = employee_repo.find_by_email(data.email)
 
         if employee is None:
-            return error_response('Employee not found.', 404)
+            return error_response(EMPLOYEE_NOT_FOUND_ERROR, 404)
 
         return json_response(employee_to_dict(employee), 200)

--- a/tests/blueprints/test_employee.py
+++ b/tests/blueprints/test_employee.py
@@ -10,6 +10,7 @@ from unittest_parametrize import ParametrizedTestCase, parametrize
 from werkzeug.test import TestResponse
 
 from app import create_app
+from blueprints.employee import EMPLOYEE_NOT_FOUND_ERROR
 from models import Employee, InvitationResponse, InvitationStatus, Role
 from repositories import DuplicateEmailError, EmployeeRepository
 
@@ -77,7 +78,14 @@ class TestEmployee(ParametrizedTestCase):
             headers={'X-Apigateway-Api-Userinfo': token_encoded},
         )
 
-    def test_info_employee_not_found(self) -> None:
+    @parametrize(
+        'api_method',
+        [
+            ('info',),
+            ('get',),
+        ],
+    )
+    def test_info_employee_not_found(self, api_method: str) -> None:
         token = self.gen_token_employee(
             client_id=cast(str, self.faker.uuid4()),
             role=self.faker.random_element(list(Role)),
@@ -88,21 +96,26 @@ class TestEmployee(ParametrizedTestCase):
 
         cast(Mock, employee_repo_mock.get).return_value = None
         with self.app.container.employee_repo.override(employee_repo_mock):
-            resp = self.call_info_api_employee(token)
+            if api_method == 'info':
+                resp = self.call_info_api_employee(token)
+            else:
+                resp = self.client.get(f'/api/v1/employees/{token["cid"]}/{token["sub"]}')
 
         self.assertEqual(resp.status_code, 404)
         resp_data = json.loads(resp.get_data())
 
-        self.assertEqual(resp_data, {'code': 404, 'message': 'Employee not found'})
+        self.assertEqual(resp_data, {'code': 404, 'message': EMPLOYEE_NOT_FOUND_ERROR})
 
     @parametrize(
-        'assigned',
+        ['assigned', 'api_method'],
         [
-            (True,),
-            (False,),
+            (True, 'info'),
+            (False, 'info'),
+            (True, 'get'),
+            (False, 'get'),
         ],
     )
-    def test_info_employee_found(self, *, assigned: bool) -> None:
+    def test_info_employee_found(self, *, assigned: bool, api_method: str) -> None:
         invitation_status = (
             self.faker.random_element([InvitationStatus.ACCEPTED, InvitationStatus.UNINVITED])
             if assigned
@@ -130,7 +143,11 @@ class TestEmployee(ParametrizedTestCase):
 
         cast(Mock, employee_repo_mock.get).return_value = employee
         with self.app.container.employee_repo.override(employee_repo_mock):
-            resp = self.call_info_api_employee(token)
+            if api_method == 'info':
+                resp = self.call_info_api_employee(token)
+            else:
+                cid = token['cid'] or '00000000-0000-0000-0000-000000000000'
+                resp = self.client.get(f'/api/v1/employees/{cid}/{token["sub"]}')
 
         self.assertEqual(resp.status_code, 200)
         resp_data = json.loads(resp.get_data())
@@ -140,6 +157,31 @@ class TestEmployee(ParametrizedTestCase):
         self.assertEqual(resp_data['name'], employee.name)
         self.assertEqual(resp_data['email'], employee.email)
         self.assertEqual(resp_data['role'], employee.role)
+
+    @parametrize(
+        ['param'],
+        [
+            ('client_id',),
+            ('employee_id',),
+        ],
+    )
+    def test_get_employee_invalid(self, param: str) -> None:
+        client_id = self.faker.word() if param == 'client_id' else cast(str, self.faker.uuid4())
+        employee_id = self.faker.word() if param == 'employee_id' else cast(str, self.faker.uuid4())
+
+        employee_repo_mock = Mock(EmployeeRepository)
+
+        cast(Mock, employee_repo_mock.get).return_value = None
+        with self.app.container.employee_repo.override(employee_repo_mock):
+            resp = self.client.get(f'/api/v1/employees/{client_id}/{employee_id}')
+
+        cast(Mock, employee_repo_mock.get).assert_not_called()
+
+        self.assertEqual(resp.status_code, 400)
+        resp_data = json.loads(resp.get_data())
+
+        self.assertEqual(resp_data['code'], 400)
+        self.assertEqual(resp_data['message'], 'Invalid client ID.' if param == 'client_id' else 'Invalid employee ID.')
 
     def test_register_employee_success(self) -> None:
         employee_repo_mock = Mock(EmployeeRepository)
@@ -425,7 +467,7 @@ class TestEmployee(ParametrizedTestCase):
 
         self.assertEqual(resp.status_code, 404)
         resp_data = json.loads(resp.get_data())
-        self.assertEqual(resp_data['message'], 'Employee not found.')
+        self.assertEqual(resp_data['message'], EMPLOYEE_NOT_FOUND_ERROR)
 
     def test_accept_invitation_success(self) -> None:
         client_id = cast(str, self.faker.uuid4())
@@ -476,7 +518,7 @@ class TestEmployee(ParametrizedTestCase):
 
         self.assertEqual(resp.status_code, 404)
         resp_data = json.loads(resp.get_data())
-        self.assertEqual(resp_data['message'], 'Employee not found')
+        self.assertEqual(resp_data['message'], EMPLOYEE_NOT_FOUND_ERROR)
 
     def test_invitation_already_accepted(self) -> None:
         token = self.gen_token_employee(client_id=cast(str, self.faker.uuid4()), role=Role.AGENT, assigned=True)
@@ -556,7 +598,7 @@ class TestEmployee(ParametrizedTestCase):
 
         self.assertEqual(resp.status_code, 404)
         resp_data = json.loads(resp.get_data())
-        self.assertEqual(resp_data, {'code': 404, 'message': 'Employee not found.'})
+        self.assertEqual(resp_data, {'code': 404, 'message': EMPLOYEE_NOT_FOUND_ERROR})
 
     def test_employee_detail_forbidden(self) -> None:
         token = self.gen_token_employee(client_id=cast(str, self.faker.uuid4()), role=Role.AGENT, assigned=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint for retrieving employee details using `client_id` and `employee_id`.
	- Added validation for ID parameters with appropriate error responses for invalid inputs.
	- Implemented a constant for standardized error messaging when an employee is not found.

- **Bug Fixes**
	- Enhanced error handling for scenarios where employee details cannot be found.

- **Tests**
	- Improved test coverage with parameterization for employee retrieval methods.
	- Added tests for handling invalid `client_id` and `employee_id` scenarios.
	- Updated tests to use a constant for error messaging consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->