### PR TITLE
Request parameter para obtener cliente con plan

### DIFF
--- a/blueprints/client.py
+++ b/blueprints/client.py
@@ -156,7 +156,9 @@ class RetrieveClient(MethodView):
 
         client = client_repo.get(client_id)
 
+        include_plan = request.args.get('include_plan', 'false').lower() == 'true'
+
         if client is None:
             return error_response('Client not found.', 404)
 
-        return json_response(client_to_dict(client), 200)
+        return json_response(client_to_dict(client, include_plan=include_plan), 200)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional query parameter `include_plan` in the API response to allow clients to request plan information.
  
- **Bug Fixes**
	- Enhanced error handling for client ID validation remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->