### PR TITLE
:sparkles: adding agent to get_client info

### DIFF
--- a/blueprints/client.py
+++ b/blueprints/client.py
@@ -115,9 +115,9 @@ class ClientInfo(MethodView):
         if client is None:
             return error_response('Client not found.', 404)
 
-        is_admin: bool = token['role'] == Role.ADMIN.value
+        is_admin_or_agent: bool = token['role'] == Role.ADMIN.value or token['role'] == Role.AGENT.value
 
-        return json_response(client_to_dict(client, include_plan=is_admin), 200)
+        return json_response(client_to_dict(client, include_plan=is_admin_or_agent), 200)
 
 
 @class_route(blp, '/api/v1/clients/me/plan/<plan>')

--- a/tests/blueprints/test_client.py
+++ b/tests/blueprints/test_client.py
@@ -130,7 +130,7 @@ class TestClient(ParametrizedTestCase):
         [
             ('get', None, False),
             ('info', Role.ADMIN, True),
-            ('info', Role.AGENT, False),
+            ('info', Role.AGENT, True),
             ('info', Role.ANALYST, False),
             ('find', None, True),
         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced role-based access to client plan information for users with `ADMIN` or `AGENT` roles.
  
- **Bug Fixes**
	- Updated test cases to reflect the new behavior of including plan information for users with the `AGENT` role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->